### PR TITLE
Prevent errors if include file is double-included and fix some typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ rel/example_project
 .rebar
 .project
 .settings
+*~

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A quick way to include font-awesome incons into nitrogen; small record name; ass
 
 This creates a `#fa{}` element for [Nitrogen Web Framework](http://nitrogenproject.com) 
 
-## Installing into a Nitrogen Applicatio
+## Installing into a Nitrogen Application
 
 Add it as a rebar dependency by adding into the deps section of rebar.config:
 
@@ -12,7 +12,7 @@ Add it as a rebar dependency by adding into the deps section of rebar.config:
 {nitrogen_fa, "", {git, "git://github.com/stuart-thackray/nitrogen_fa.git", {branch, master}}}
 ```
 
-You need to include font awsume CSS/Fonts/etc this can either be done with the below or you can use a [CDN](https://en.wikipedia.org/wiki/Content_delivery_network)
+You need to include font awesome CSS/Fonts/etc this can either be done with the below or you can use a [CDN](https://en.wikipedia.org/wiki/Content_delivery_network)
 
 To include the included CSS version 4.6.2 you can include like below in your template
 ```html

--- a/include/records.hrl
+++ b/include/records.hrl
@@ -4,7 +4,7 @@
 -record(fa, {?ELEMENT_BASE(element_fa),
         text=""                 :: text(),
         body=" "                 :: body,
-        fa                      :: text()       % Font awsume icon
+        fa                      :: text()       % Font awesome icon
         }).
 
 -endif.

--- a/include/records.hrl
+++ b/include/records.hrl
@@ -1,7 +1,10 @@
-
+-ifndef(nitrogen_fa_include).
+-define(nitrogen_fa_include, 1).
 
 -record(fa, {?ELEMENT_BASE(element_fa),
         text=""                 :: text(),
         body=" "                 :: body,
 		fa 						:: text()		% Font awsume icon
 		}).
+
+-endif.

--- a/include/records.hrl
+++ b/include/records.hrl
@@ -4,7 +4,7 @@
 -record(fa, {?ELEMENT_BASE(element_fa),
         text=""                 :: text(),
         body=" "                 :: body,
-		fa 						:: text()		% Font awsume icon
-		}).
+        fa                      :: text()       % Font awsume icon
+        }).
 
 -endif.


### PR DESCRIPTION
If nitrogen_fa file was included twice for some reason, the compile would fail. Adding ifndef's around them will prevent this problem.

Also fixed some typos and a mix of spaces and tabs in the records.hrl file that ended up being a little crazy.

Thanks!