### PR TITLE
Adding Size and FW attributes, and expanding functionality a bit

### DIFF
--- a/include/records.hrl
+++ b/include/records.hrl
@@ -2,9 +2,11 @@
 -define(nitrogen_fa_include, 1).
 
 -record(fa, {?ELEMENT_BASE(element_fa),
-        text=""                 :: text(),
-        body=" "                 :: body,
-        fa                      :: text()       % Font awesome icon
+            text=""                 :: text(),
+            body=" "                 :: body,
+            fa                      :: text(), % Font awesome icon
+            size=""                 :: text(),
+            fw=false                :: boolean()
         }).
 
 -endif.

--- a/include/records.hrl
+++ b/include/records.hrl
@@ -2,11 +2,11 @@
 -define(nitrogen_fa_include, 1).
 
 -record(fa, {?ELEMENT_BASE(element_fa),
-            text=""                 :: text(),
-            body=" "                 :: body,
-            fa                      :: text(), % Font awesome icon
-            size=""                 :: text(),
-            fw=false                :: boolean()
+             text=""                 :: text(),
+             body=" "                :: body(),
+             fa                      :: text() | atom(), % Font awesome icon
+             size=""                 :: text() | atom(),
+             fw=false                :: boolean()    %% fixed-width
         }).
 
 -endif.

--- a/src/element_fa.erl
+++ b/src/element_fa.erl
@@ -14,7 +14,9 @@ reflect() -> record_info(fields, fa).
 render_element(_Record = #fa{text = Text,
                             body = Body,
                             class = Class0,
+                            style = Style,
                             size = Size,
+                            html_id = Htmlid,
                             fa = Icon,
                             fw = FixedWidth}) ->
    
@@ -27,7 +29,9 @@ render_element(_Record = #fa{text = Text,
 
     UniversalAttributes = [
                             {class, Class},
-                            {"aria-hidden", "true"}
+                            {"aria-hidden", "true"},
+                            {style, Style},
+                            {id, Htmlid}
                            ],
     
     wf_tags:emit_tag(i, [Body, Text], UniversalAttributes).

--- a/src/element_fa.erl
+++ b/src/element_fa.erl
@@ -1,6 +1,7 @@
+%% vim: ts=4 sw=4 et
 -module (element_fa).
 -include_lib ("nitrogen_core/include/wf.hrl").
--include_lib ("../include/records.hrl").
+-include("records.hrl").
 -export([
     reflect/0,
     render_element/1
@@ -10,12 +11,23 @@ reflect() -> record_info(fields, fa).
 
 
 -spec render_element(#fa{}) -> body().
-render_element(Record = #fa{text = Text,
-							body = Body}) ->
-    
+render_element(_Record = #fa{text = Text,
+                            body = Body,
+                            class = Class0,
+                            size = Size,
+                            fa = Icon,
+                            fw = FixedWidth}) ->
+   
+    Class = [
+        "fa fa-" ++ wf:to_list(Icon),
+        ?WF_IF(Size, "fa-" ++ wf:to_list(Size)),
+        ?WF_IF(FixedWidth, "fa-fw")
+        | Class0
+    ],
+
     UniversalAttributes = [
-    						{class, "fa fa-" ++ Record#fa.fa},
-							{"aria-hidden", "true"}
-						   ],
-	
-	wf_tags:emit_tag(i, [Body, Text], UniversalAttributes).
+                            {class, Class},
+                            {"aria-hidden", "true"}
+                           ],
+    
+    wf_tags:emit_tag(i, [Body, Text], UniversalAttributes).


### PR DESCRIPTION
Hey Stuart,

I've started using this in one of my projects non-bootstrap projects and found it quite handy.

But I also needed some of the other functions - the size multiplier and the fixed-width option.

Additionally, I expanded this to carry over the class, style, and HTML ID.

For the future, for FontAwesome 5.0, keep in mind the "fa" prefix was deprecated with it being replaced with "fas", "far", and "fat" (or something like that)