### PR TITLE
Use rand instead of random module (random was deprecated a while ago)

### DIFF
--- a/src/fa_demo.erl
+++ b/src/fa_demo.erl
@@ -8,12 +8,10 @@ main() -> #template { file="./site/templates/plugins/nitrogen_fa/fa_demo.html" }
 
 
 body() -> 
-	{A,B,C} = os:timestamp(),
-	random:seed(A, B, C),
     [
 
 	[[#panel{ style=["font-size: 24px;text-align: center;background-color: ",
-					 case random:uniform(1000) rem 2 of
+					 case rand:uniform(1000) rem 2 of
 						 0 ->
 							 "#f9f9f9;";
 						1 ->


### PR DESCRIPTION
This just updates the demo page to to use rand:uniform instead of random:uniform (the latter being deprecated for a couple years).